### PR TITLE
move "install project" from dockerfile to entrypoint file

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -31,7 +31,4 @@ WORKDIR /opt/alcali/code
 # Install dependencies
 RUN pip install --user -U setuptools
 
-# Install project
-RUN pip install --user -e .[dev,ldap,social] mysqlclient
-
 ENTRYPOINT ["/opt/alcali/code/docker/utils/entrypoint-dev.sh"]

--- a/docker/utils/entrypoint-dev.sh
+++ b/docker/utils/entrypoint-dev.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Install project
+pip install --user .[ldap,social] mysqlclient psycopg2
+
 # Wait for database
 echo "Waiting for $DB_HOST"
 ./docker/utils/wait-for -t 60 $DB_HOST:$DB_PORT


### PR DESCRIPTION
Possibly because of PYTHONPATH: this line in the dockerfile does not succeed.

Moving it to the entrypoint script allows it be run correctly and succeed with project install. 

Without this change attempting run the "alcali" CLI utility fails with:

> [root@alcalidocker alcali]# docker exec -it 64963bd86489 alcali --version
Traceback (most recent call last):
  File "/opt/alcali/.local/bin/alcali", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3258, in <module>
    @_call_aside
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3242, in _call_aside
    f(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3271, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 584, in _build_master
    ws.require(__requires__)
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 901, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 787, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'alcali' distribution was not found and is required by the application

In this branch the result is:

> docker exec -it 764f7958d611 alcali --version
3.0.5