### PR TITLE
Order return dict for correct result parsing in Vue.JS

### DIFF
--- a/api/views/alcali.py
+++ b/api/views/alcali.py
@@ -510,11 +510,13 @@ def run(request):
             parsed_command[0]["fun"] in ["state.apply", "state.highstate"]
             and parsed_command[0]["client"] != "local_async"
         ):
+            ret = dict(sorted(ret.items(), reverse=True))
             for state, out in ret.items():
                 minion_ret = highstate_output.output({state: out})
                 formatted += minion_ret + "\n\n"
         # Everything else.
         else:
+            ret = dict(sorted(ret.items(), reverse=True))
             for state, out in ret.items():
                 minion_ret = nested_output.output({state: out})
                 formatted += minion_ret + "\n\n"


### PR DESCRIPTION
In [RunCard.vue#L376](https://github.com/latenighttales/alcali/blob/develop/src/components/RunCard.vue#L376) it's expected that the first part of the return value is always the `jid` so the links are generated correctly. But the dict isn't ordered so if you've more minions it could happen that the `jid` is the last entry in the dict.

This code sort the dict in reverse order so `jid` is always the first part of the dict.