### PR TITLE
Fix SLS error output on conformity details per minion

### DIFF
--- a/api/utils/output/nested_output.py
+++ b/api/utils/output/nested_output.py
@@ -72,9 +72,12 @@ class NestDisplay(object):
             )
         elif isinstance(ret, str):
             first_line = True
+            color = self.GREEN
+            if self.retcode != 0:
+                color = self.RED
             for line in ret.splitlines():
                 line_prefix = " " * len(prefix) if not first_line else prefix
-                out.append(self.ustring(indent, self.GREEN, line, prefix=line_prefix))
+                out.append(self.ustring(indent, color, line, prefix=line_prefix))
                 first_line = False
         elif isinstance(ret, (list, tuple)):
             color = self.GREEN

--- a/api/views/alcali.py
+++ b/api/views/alcali.py
@@ -178,7 +178,7 @@ class MinionsViewSet(viewsets.ModelViewSet):
             last_highstate = last_highstate.loaded_ret()["return"]
             # Sls error
             if isinstance(last_highstate, list):
-                failed = {"error": last_highstate[0]}
+                failed = {'error': conv.convert(nested_output.output('\n'.join(last_highstate), _retcode = 1))}
             else:
                 for state in last_highstate:
                     state_name = state.split("_|-")[1]


### PR DESCRIPTION
On the light theme an sls error is not shown because the font color is also black. Because it's an error the font color should be red and I also recommend to show all errors logged by the state.

Using the existing method for the nested_output and adding color support if a string is used.