### PR TITLE
Long pillar data is rendered slow by codemirror

### DIFF
--- a/src/components/MinionDetailCard.vue
+++ b/src/components/MinionDetailCard.vue
@@ -127,5 +127,7 @@
     right: 0;
     z-index: 1;
   }
-
+  .vue-codemirror {
+    height: 800px !important;
+  }
 </style>

--- a/src/components/core/Fab.vue
+++ b/src/components/core/Fab.vue
@@ -53,5 +53,7 @@
 </script>
 
 <style scoped>
-
+  .v-speed-dial {
+    z-index: 10;
+  }
 </style>


### PR DESCRIPTION
If the pillar data is big and nested loading the pillar tab on the minion page takes really long. Sometimes the browser freezes completely. The easiest solution (and maybe only a workaround) would the limitation of vue-codemirror window size.

Additional to that change a scroll bare is automatically added to the vue-codemirror window. For that reason it's required to modify the v-speed-dial button index to be always on top.