### PR TITLE
fix(requirements): django simplejwt can't be installed

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -3,7 +3,7 @@ Django==3.1.13
 django-cors-headers==3.7.0
 django-currentuser==0.5.3
 djangorestframework==3.12.2
-djangorestframework-simplejwt==4.4.0
+djangorestframework-simplejwt==4.6.0
 gunicorn==20.1.0
 PyJWT==1.7.1
 python-dotenv==0.18.0


### PR DESCRIPTION
We can't install Alcali with the current requirements:

```
ERROR: Could not find a version that satisfies the requirement
djangorestframework-simplejwt==4.4.0
```

When relaxing the version, it install 4.6.0.

* requirements/prod.txt (djangorestframework-simplejwt): install
  version 4.6.0