### PR TITLE
Update python docker image for dev tests

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-stretch
+FROM python:3.7-slim-buster
 
 MAINTAINER Matt Melquiond
 

--- a/docker/Dockerfile-master
+++ b/docker/Dockerfile-master
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-stretch
+FROM python:3.7-slim-buster
 
 # Upgrade System and Install dependencies
 RUN apt-get update && \

--- a/docker/Dockerfile-minion
+++ b/docker/Dockerfile-minion
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-stretch
+FROM python:3.7-slim-buster
 
 # Upgrade System and Install dependencies
 RUN apt-get update && \


### PR DESCRIPTION
Update image from python:3.7-slim-stretch to python:3.7-slim-buster to avoid error :
Failed to fetch https://repo.saltproject.io/py3/debian/9/amd64/latest/pool/main/s/salt/salt-api_3003+ds-1_all.deb  404  Not Found