### PR TITLE
Fix line-height in overview menu (Jobs State graph title)

### DIFF
--- a/src/components/JobsChartCard.vue
+++ b/src/components/JobsChartCard.vue
@@ -165,4 +165,7 @@ export default {
 </script>
 
 <style scoped>
+.v-list-item--dense .v-list-item__title{
+  line-height: 1;
+}
 </style>


### PR DESCRIPTION
In overview menu, the Job Stats title was partially display. (The bottom of the characters was hide) This modification fix that.