### PR TITLE
fix!: allow AUTH_LDAP_START_TLS to be False

### DIFF
--- a/config/ldap_config.py
+++ b/config/ldap_config.py
@@ -29,7 +29,7 @@ AUTH_LDAP_USER_ATTR_MAP = {
     "email": os.environ.get("AUTH_LDAP_USER_ATTR_MAP_EMAIL", "mail"),
 }
 
-AUTH_LDAP_START_TLS = os.environ.get("AUTH_LDAP_START_TLS", "True").lower() in ("y", "yes", "t", "true", "on", "1")
+AUTH_LDAP_START_TLS = os.environ.get("AUTH_LDAP_START_TLS", "False").lower() in ("y", "yes", "t", "true", "on", "1")
 
 # This is the default.
 AUTH_LDAP_ALWAYS_UPDATE_USER = True

--- a/config/ldap_config.py
+++ b/config/ldap_config.py
@@ -29,8 +29,7 @@ AUTH_LDAP_USER_ATTR_MAP = {
     "email": os.environ.get("AUTH_LDAP_USER_ATTR_MAP_EMAIL", "mail"),
 }
 
-if os.environ.get("AUTH_LDAP_START_TLS"):
-    AUTH_LDAP_START_TLS = True
+AUTH_LDAP_START_TLS = os.environ.get("AUTH_LDAP_START_TLS", "True").lower() in ("y", "yes", "t", "true", "on", "1")
 
 # This is the default.
 AUTH_LDAP_ALWAYS_UPDATE_USER = True

--- a/config/ldap_config.py
+++ b/config/ldap_config.py
@@ -29,7 +29,14 @@ AUTH_LDAP_USER_ATTR_MAP = {
     "email": os.environ.get("AUTH_LDAP_USER_ATTR_MAP_EMAIL", "mail"),
 }
 
-AUTH_LDAP_START_TLS = os.environ.get("AUTH_LDAP_START_TLS", "False").lower() in ("y", "yes", "t", "true", "on", "1")
+AUTH_LDAP_START_TLS = os.environ.get("AUTH_LDAP_START_TLS", "False").lower() in (
+    "y",
+    "yes",
+    "t",
+    "true",
+    "on",
+    "1",
+)
 
 # This is the default.
 AUTH_LDAP_ALWAYS_UPDATE_USER = True


### PR DESCRIPTION
This change allow the AUTH_LDAP_START_TLS flag to be set to `False`. In the past, StartTLS would be enabled even if `AUTH_LDAP_START_TLS="False"` was specified in the configuration. This has high probability of leading to user-error, especially when configuring alcali with the alcali-playbook which sets it to False, and also contradicts the [ldap module documentation](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-start-tls).

String comparison was used instead of `strtobool`, because the [distutils module is deprecated](https://peps.python.org/pep-0632/) and will be removed by Python 3.12. The collection of values to compare against was copied from `settings.py` in order to have matching behavior of [DJANGO_DEBUG](https://github.com/latenighttales/alcali/blob/v3003.1.0/config/settings.py#L36).

This commit is marked as breaking because it can theoretically break setups for people who have historically configured this environment variable with a bogus value, and upgrading Alcali therefore risk breaking that environment. Although this risk can in my opinion be considered acceptable due to the forgiving amount of acceptable values, as well as using anything other than `True` is technically against documentation.