### PR TITLE
update `python-ldap` to `v3.4.3` to support `openldap26-client` pkg on FreeBSD

### DIFF
--- a/requirements/ldap.txt
+++ b/requirements/ldap.txt
@@ -1,2 +1,2 @@
 django-auth-ldap==2.3.0
-python-ldap==3.4.0
+python-ldap==3.4.3


### PR DESCRIPTION
Hello @mattLLVW.
This PR is addressed to you in order to support newer `openldap-client` for `FreeBSD`.
Blocking issue to build `python-ldap` against `openldap26-client` were fixed in `v3.4.2`
-> https://github.com/python-ldap/python-ldap/releases/tag/python-ldap-3.4.2

Last version is `v3.4.3`.
Tested on `FreeBSD`, working as expected.
