### PR TITLE
lots of little fixes

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -40,7 +40,7 @@ class SaltReturns(models.Model):
     id = models.CharField(max_length=255, primary_key=True)
     success = models.CharField(max_length=10)
     full_ret = models.TextField()
-    alter_time = models.DateTimeField(tzinfo=None)
+    alter_time = models.DateTimeField()
 
     objects = FindJobManager()
 
@@ -88,7 +88,7 @@ class SaltEvents(models.Model):
     id = models.BigAutoField(primary_key=True)
     tag = models.CharField(max_length=255, db_index=True)
     data = models.TextField()
-    alter_time = models.DateTimeField(tzinfo=None)
+    alter_time = models.DateTimeField()
     master_id = models.CharField(max_length=255)
 
     class Meta:

--- a/api/models.py
+++ b/api/models.py
@@ -145,7 +145,7 @@ class Minions(models.Model):
         # Get all potential jobs.
         states = SaltReturns.objects.filter(
             Q(fun="state.apply") | Q(fun="state.highstate"), id=self.minion_id
-        ).order_by('jid')[0:2]
+        ).order_by('-jid')[0:2]
         states = sorted(states, key=lambda x: x.jid)
 
         # Remove jobs with arguments.

--- a/api/models.py
+++ b/api/models.py
@@ -145,7 +145,7 @@ class Minions(models.Model):
         # Get all potential jobs.
         states = SaltReturns.objects.filter(
             Q(fun="state.apply") | Q(fun="state.highstate"), id=self.minion_id
-        )
+        ).order_by('jid').desc()[0:10]
         states = sorted(states, key=lambda x: x.jid, reverse=True)
 
         # Remove jobs with arguments.

--- a/api/models.py
+++ b/api/models.py
@@ -171,8 +171,9 @@ class Minions(models.Model):
 
         for state in return_item:
             # One of the state is not ok
-            if not return_item.get(state, {}).get("result"):
-                return False
+            if type(return_item) == dict:
+                if not return_item.get(state, {}).get("result"):
+                    return False
         return True
 
     def custom_conformity(self, fun, *args):

--- a/api/models.py
+++ b/api/models.py
@@ -146,7 +146,7 @@ class Minions(models.Model):
         states = SaltReturns.objects.filter(
             Q(fun="state.apply") | Q(fun="state.highstate"), id=self.minion_id
         ).order_by('jid')[0:2]
-        states = sorted(states, key=lambda x: x.jid, reverse=True)
+        states = sorted(states, key=lambda x: x.jid)
 
         # Remove jobs with arguments.
         for state in states:

--- a/api/models.py
+++ b/api/models.py
@@ -93,6 +93,7 @@ class SaltReturns(models.Model):
         managed = False
         db_table = "salt_returns"
         app_label = "api"
+        ordering = ['-id']
 
 
 class SaltEvents(models.Model):
@@ -106,6 +107,7 @@ class SaltEvents(models.Model):
         managed = False
         db_table = "salt_events"
         app_label = "api"
+        ordering = ['-id']
 
 
 # Alcali custom.

--- a/api/models.py
+++ b/api/models.py
@@ -78,6 +78,17 @@ class SaltReturns(models.Model):
                 return ret["return"]["result"]
         return self.jid
 
+    def valid_for_highstate(self):
+        valid_for_highstate = True
+        if not self.loaded_ret()["fun_args"]:
+            valid_for_highstate = True
+        if isinstance(self.loaded_ret()["fun_args"], list) and self.loaded_ret()["fun_args"]:
+            if self.loaded_ret()["fun_args"][0] == {"test": True}:
+                valid_for_highstate = False
+            if self.loaded_ret()["fun_args"][0] == "test=True":
+                valid_for_highstate = False
+        return valid_for_highstate
+
     class Meta:
         managed = False
         db_table = "salt_returns"
@@ -150,11 +161,7 @@ class Minions(models.Model):
 
         # Remove jobs with arguments.
         for state in states:
-            if (
-                not state.loaded_ret()["fun_args"]
-                or state.loaded_ret()["fun_args"][0] == {"test": True}
-                or state.loaded_ret()["fun_args"][0] == "test=True"
-            ):
+            if state.valid_for_highstate():
                 return state
         return None
 

--- a/api/models.py
+++ b/api/models.py
@@ -40,7 +40,7 @@ class SaltReturns(models.Model):
     id = models.CharField(max_length=255, primary_key=True)
     success = models.CharField(max_length=10)
     full_ret = models.TextField()
-    alter_time = models.DateTimeField()
+    alter_time = models.DateTimeField(tzinfo=None)
 
     objects = FindJobManager()
 
@@ -88,7 +88,7 @@ class SaltEvents(models.Model):
     id = models.BigAutoField(primary_key=True)
     tag = models.CharField(max_length=255, db_index=True)
     data = models.TextField()
-    alter_time = models.DateTimeField()
+    alter_time = models.DateTimeField(tzinfo=None)
     master_id = models.CharField(max_length=255)
 
     class Meta:

--- a/api/models.py
+++ b/api/models.py
@@ -145,7 +145,7 @@ class Minions(models.Model):
         # Get all potential jobs.
         states = SaltReturns.objects.filter(
             Q(fun="state.apply") | Q(fun="state.highstate"), id=self.minion_id
-        ).order_by('jid').desc()[0:10]
+        ).order_by('jid').first()
         states = sorted(states, key=lambda x: x.jid, reverse=True)
 
         # Remove jobs with arguments.

--- a/api/models.py
+++ b/api/models.py
@@ -145,7 +145,7 @@ class Minions(models.Model):
         # Get all potential jobs.
         states = SaltReturns.objects.filter(
             Q(fun="state.apply") | Q(fun="state.highstate"), id=self.minion_id
-        ).order_by('jid').first()
+        ).order_by('jid')[0:2]
         states = sorted(states, key=lambda x: x.jid, reverse=True)
 
         # Remove jobs with arguments.

--- a/api/views/alcali.py
+++ b/api/views/alcali.py
@@ -259,11 +259,15 @@ class ConformityViewSet(viewsets.ModelViewSet):
                     succeeded, unchanged, failed = None, None, 1
                 else:
                     for state in last_highstate:
-                        if last_highstate[state]["result"] is True:
-                            succeeded += 1
-                        elif last_highstate[state]["result"] is None:
-                            unchanged += 1
+                        if isinstance(last_highstate, dict):
+                            if last_highstate[state]["result"] is True:
+                                succeeded += 1
+                            elif last_highstate[state]["result"] is None:
+                                unchanged += 1
+                            else:
+                                failed += 1
                         else:
+                            # most likely a string response containing "Unhandled exception running state.highstate"
                             failed += 1
             else:
                 last_highstate_date, succeeded, unchanged, failed = (

--- a/api/views/salt.py
+++ b/api/views/salt.py
@@ -35,7 +35,7 @@ class SaltReturnsList(generics.ListAPIView):
         qry = {}
         start = self.request.query_params.get("start", None)
         end = self.request.query_params.get("end", None)
-        limit = int(self.request.query_params.get("limit", 200))
+        limit = int(self.request.query_params.get("limit", 50))
         target = self.request.query_params.getlist("target[]")
         users = self.request.query_params.getlist("users[]", None)
         if target:

--- a/api/views/salt.py
+++ b/api/views/salt.py
@@ -57,8 +57,8 @@ class SaltReturnsListJid(generics.ListAPIView):
 
     def get_queryset(self):
         jid = self.kwargs["jid"]
-        queryset = SaltReturns.objects.all()
-        return queryset.filter(jid=jid).order_by("-alter_time")
+        queryset = SaltReturns.objects.filter(jid=jid).order_by("-alter_time")
+        return queryset
 
 
 @api_view(["GET"])
@@ -97,5 +97,5 @@ class EventsViewSet(viewsets.ReadOnlyModelViewSet):
     A simple ViewSet for viewing accounts.
     """
 
-    queryset = SaltEvents.objects.all().order_by("-alter_time")[:200]
+    queryset = SaltEvents.objects.all().order_by("-alter_time")[:50]
     serializer_class = EventsSerializer

--- a/api/views/salt.py
+++ b/api/views/salt.py
@@ -67,7 +67,7 @@ def jobs_filters(request):
 
     # THIS is eating through ram and cpu...
     # user_list = list({i.user() for i in Jids.objects.all()}) # THIS is eating through ram and cpu...
-    user_list = Jids.objects.values_list('user', flat=True).distinct()
+    user_list = list()
     minion_list = SaltReturns.objects.values_list("id", flat=True).distinct()
     return Response({"users": user_list, "minions": minion_list})
 

--- a/api/views/salt.py
+++ b/api/views/salt.py
@@ -35,7 +35,7 @@ class SaltReturnsList(generics.ListAPIView):
         qry = {}
         start = self.request.query_params.get("start", None)
         end = self.request.query_params.get("end", None)
-        limit = int(self.request.query_params.get("limit", 50))
+        limit = int(self.request.query_params.get("limit", 200))
         target = self.request.query_params.getlist("target[]")
         users = self.request.query_params.getlist("users[]", None)
         if target:
@@ -100,5 +100,5 @@ class EventsViewSet(viewsets.ReadOnlyModelViewSet):
     A simple ViewSet for viewing accounts.
     """
 
-    queryset = SaltEvents.objects.all().order_by("-alter_time")[:50]
+    queryset = SaltEvents.objects.all().order_by("-alter_time")[:200]
     serializer_class = EventsSerializer

--- a/api/views/salt.py
+++ b/api/views/salt.py
@@ -64,7 +64,7 @@ class SaltReturnsListJid(generics.ListAPIView):
 @api_view(["GET"])
 def jobs_filters(request):
     # Filter options.
-    user_list = list({i.user() for i in Jids.objects.all()})
+    user_list =  list() # list({i.user() for i in Jids.objects.all()}) # THIS is eating through ram and cpu...
     minion_list = SaltReturns.objects.values_list("id", flat=True).distinct()
     return Response({"users": user_list, "minions": minion_list})
 

--- a/api/views/salt.py
+++ b/api/views/salt.py
@@ -64,7 +64,10 @@ class SaltReturnsListJid(generics.ListAPIView):
 @api_view(["GET"])
 def jobs_filters(request):
     # Filter options.
-    user_list =  list() # list({i.user() for i in Jids.objects.all()}) # THIS is eating through ram and cpu...
+
+    # THIS is eating through ram and cpu...
+    # user_list = list({i.user() for i in Jids.objects.all()}) # THIS is eating through ram and cpu...
+    user_list = Jids.objects.values_list('user', flat=True).distinct()
     minion_list = SaltReturns.objects.values_list("id", flat=True).distinct()
     return Response({"users": user_list, "minions": minion_list})
 

--- a/api/views/salt.py
+++ b/api/views/salt.py
@@ -100,5 +100,5 @@ class EventsViewSet(viewsets.ReadOnlyModelViewSet):
     A simple ViewSet for viewing accounts.
     """
 
-    queryset = SaltEvents.objects.all().order_by("-alter_time")[:200]
+    queryset = SaltEvents.objects.all().order_by("-id")[:200]
     serializer_class = EventsSerializer

--- a/config/settings.py
+++ b/config/settings.py
@@ -42,6 +42,7 @@ else:
     DJANGO_DEBUG = False
 DEBUG = DJANGO_DEBUG
 
+
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "127.0.0.1").split(" ")
 
 # Application definition
@@ -124,6 +125,9 @@ LANGUAGE_CODE = "en-us"
 USE_I18N = True
 
 USE_L10N = True
+
+USE_TZ = True
+TIME_ZONE = "UTC"
 
 # Static files (CSS, JavaScript, Images)
 # Place static in the same location as webpack build files

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -32,6 +32,6 @@ WORKDIR /opt/alcali/code
 RUN pip install --user -U setuptools
 
 # Install project
-RUN pip install --user -e .[dev,ldap,social] mysqlclient
+RUN pip install --user -e .[dev,ldap,social] mysqlclient psycopg2
 
 ENTRYPOINT ["/opt/alcali/code/docker/utils/entrypoint-dev.sh"]


### PR DESCRIPTION
we found several issues that made alcali unusable on a large salt instance.
the minions list or conformity would not load at all. 
there was an assumption that it would also have a dict but some of the responses were strings (unhandled failures on the state.apply on minion side)

we have a postgres db with over 20gb of history that pointed out some of the load issues.

the "users" logic on search is the most broken piece, it does not scale and we removed it as it was unworkable. an indexing task to index jobs to pull out userid into its own column would help a lot