### PR TITLE
Fix running github-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Runner `ubuntu-18.04` does no longer exist and jobs are queued.
See https://github.com/latenighttales/alcali/actions/runs/6591416373/job/17909951608