### PR TITLE
Fix ACL expected response

### DIFF
--- a/api/views/alcali.py
+++ b/api/views/alcali.py
@@ -538,7 +538,7 @@ def verify(request):
         except User.DoesNotExist:
             return HttpResponse("Unauthorized", status=401)
         if request.POST.get("password") == user.user_settings.token:
-            return Response({request.POST.get("username"): None})
+            return Response([])
         return HttpResponse("Unauthorized", status=401)
 
 

--- a/tests/test_views_alcali.py
+++ b/tests/test_views_alcali.py
@@ -323,7 +323,7 @@ def test_search_job(admin_client, dummy_state, dummy_jid, minion_master, jwt):
 
 @pytest.mark.django_db()
 def test_verify_token(admin_client, admin_user, jwt):
-    """ Salt expects a list of ACL permissions """
+    """Salt expects a list of ACL permissions"""
     response = admin_client.post(
         "/api/token/verify/",
         {"username": admin_user.username, "password": admin_user.user_settings.token},

--- a/tests/test_views_alcali.py
+++ b/tests/test_views_alcali.py
@@ -323,12 +323,13 @@ def test_search_job(admin_client, dummy_state, dummy_jid, minion_master, jwt):
 
 @pytest.mark.django_db()
 def test_verify_token(admin_client, admin_user, jwt):
+    """ Salt expects a list of ACL permissions """
     response = admin_client.post(
         "/api/token/verify/",
         {"username": admin_user.username, "password": admin_user.user_settings.token},
         **jwt
     )
-    assert response.json()[admin_user.username] is None
+    assert isinstance(response.json(), list)
 
     response = admin_client.post(
         "/api/token/verify/",


### PR DESCRIPTION
Fixes https://github.com/saltstack/salt/issues/65408

`salt-api` expects a `list` of ACLs allowed, not a `dict`.