### PR TITLE
fix: state result can be str instead of dict

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -171,6 +171,8 @@ class Minions(models.Model):
 
         for state in return_item:
             # One of the state is not ok
+            if isinstance(return_item, str):
+                return False
             if not return_item.get(state, {}).get("result"):
                 return False
         return True

--- a/api/views/alcali.py
+++ b/api/views/alcali.py
@@ -259,7 +259,9 @@ class ConformityViewSet(viewsets.ModelViewSet):
                     succeeded, unchanged, failed = None, None, 1
                 else:
                     for state in last_highstate:
-                        if last_highstate[state]["result"] is True:
+                        if isinstance(last_highstate, str):
+                            failed += 1
+                        elif last_highstate[state]["result"] is True:
                             succeeded += 1
                         elif last_highstate[state]["result"] is None:
                             unchanged += 1

--- a/api/views/alcali.py
+++ b/api/views/alcali.py
@@ -179,6 +179,8 @@ class MinionsViewSet(viewsets.ModelViewSet):
             # Sls error
             if isinstance(last_highstate, list):
                 failed = {"error": last_highstate[0]}
+            elif isinstance(last_highstate, str):
+                failed = {"error": last_highstate}
             else:
                 for state in last_highstate:
                     state_name = state.split("_|-")[1]


### PR DESCRIPTION
Fixes #510 

A `string` may be returned as Salt JSON `result`, for example when `success: false`, the value can be `Unhandled exception running state.apply`, instead of an expected `dict` with the content.

The content of the string is not checked at the moment.