### PR TITLE
Fixing issue #529 - mysqlclient lib install

### DIFF
--- a/docker/Dockerfile-master
+++ b/docker/Dockerfile-master
@@ -15,7 +15,7 @@ RUN echo "id: master">>/etc/salt/minion
 # Install python dependencies
 RUN apt-get install -y -o DPkg::Options::=--force-confold salt-api python3-openssl default-libmysqlclient-dev pkg-config
 RUN pip install honcho
-RUN salt-pip install mysqlclient
+RUN /opt/saltstack/salt/bin/python3.10 -m pip install mysqlclient
 
 # Copy needed files
 COPY saltconfig/etc/master /etc/salt/master


### PR DESCRIPTION
Fixing the issue #529: the build fails at Step 8/17: RUN salt-pip install mysqlclient (from Dockerfile-master).

The workaround is to install mysqlclient with pip, not with salt-pip.

